### PR TITLE
Fix: Resolve multiple compilation errors

### DIFF
--- a/include/redisjson++/common_types.h
+++ b/include/redisjson++/common_types.h
@@ -23,6 +23,13 @@ struct ClientConfig {
     bool enable_tcp_keepalives = true;
     std::uint16_t tcp_keepalive_time_sec = 60; // Time in seconds for TCP keepalive
 
+// Enum for SET command conditions (NX, XX)
+enum class SetCmdCondition {
+    NONE, // No condition
+    NX,   // Set only if key does not exist
+    XX    // Set only if key already exists
+};
+
     // Retry strategy (basic example)
     int max_retries = 3;
     std::chrono::milliseconds retry_backoff_start = std::chrono::milliseconds(100);
@@ -41,6 +48,7 @@ struct SetOptions {
     bool create_path = true;        // For path-specific operations (not used by current set_json)
     bool overwrite = true;          // For Redis SET, this is implicit. For JSON specific ops, might differ.
     std::chrono::seconds ttl = std::chrono::seconds(0); // TTL (0 = no expiry)
+    SetCmdCondition condition = SetCmdCondition::NONE; // Conditional set (NX, XX)
     // bool compress = false;          // Future feature
     // bool validate_schema = false;   // Future feature
     // std::string schema_name = "";   // Future feature


### PR DESCRIPTION
- Address undeclared RedisException by using RedisJSONException and including exceptions.h.
- Define SetCmdCondition enum and add 'condition' member to SetOptions struct to fix undeclared SetCondition and member errors.
- Correct PathNotFoundException constructor calls to use valid signatures.
- Replace other undeclared exception types (JsonPatchException, RedisConfigurationException, RedisLuaScriptException) with their defined counterparts (PatchFailedException, RedisJSONException, LuaScriptException respectively).
- Resolve 'control reaches end of non-void function' warnings by ensuring all paths in relevant functions return a value or throw an exception.