### PR TITLE
Fix compilation errors and handle dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# CMake build output
+build/
+build-*/
+*.swp
+*.swo
+*~
+*.user
+*.suo
+*.ide
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+*.a
+*.so
+*.dylib
+compile_commands.json
+
+# GTest/GMock files that might be generated in source if not careful
+# Though ideally they are in the build directory
+gtest/
+gmock/
+
+# VS Code
+.vscode/
+
+# CLion
+.idea/
+
+# Backup files
+*.bak

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,13 +54,14 @@ endif()
 
 # Enable testing with GoogleTest
 enable_testing()
-find_package(GTest CONFIG REQUIRED) # Modern CMake way to find GTest
+# find_package(GTest CONFIG REQUIRED) # Modern CMake way to find GTest
+add_subdirectory(/usr/src/googletest ${CMAKE_BINARY_DIR}/googletest EXCLUDE_FROM_ALL) # Build GTest from source
 
 # Test files
 file(GLOB_RECURSE TEST_SOURCES "tests/*.cpp")
 
 add_executable(unit_tests ${TEST_SOURCES})
-target_link_libraries(unit_tests PRIVATE redisjson++ GTest::gtest_main GTest::gmock)
+target_link_libraries(unit_tests PRIVATE redisjson++ gtest_main gmock) # Link against the compiled GTest/GMock targets
 # For older GTest, might be GTest::GTest GTest::Main
 
 # Add test to CTest

--- a/CTestTestfile.cmake
+++ b/CTestTestfile.cmake
@@ -1,0 +1,8 @@
+# CMake generated Testfile for
+# Source directory: /app
+# Build directory: /app
+#
+# This file includes the relevant testing commands required for
+# testing this directory and lists subdirectories to be tested as well.
+include("/app/unit_tests[1]_include.cmake")
+subdirs("googletest")

--- a/googletest/CTestTestfile.cmake
+++ b/googletest/CTestTestfile.cmake
@@ -1,0 +1,7 @@
+# CMake generated Testfile for
+# Source directory: /usr/src/googletest
+# Build directory: /app/googletest
+#
+# This file includes the relevant testing commands required for
+# testing this directory and lists subdirectories to be tested as well.
+subdirs("googlemock")

--- a/googletest/googlemock/CTestTestfile.cmake
+++ b/googletest/googlemock/CTestTestfile.cmake
@@ -1,0 +1,7 @@
+# CMake generated Testfile for
+# Source directory: /usr/src/googletest/googlemock
+# Build directory: /app/googletest/googlemock
+#
+# This file includes the relevant testing commands required for
+# testing this directory and lists subdirectories to be tested as well.
+subdirs("../googletest")

--- a/googletest/googletest/CTestTestfile.cmake
+++ b/googletest/googletest/CTestTestfile.cmake
@@ -1,0 +1,6 @@
+# CMake generated Testfile for
+# Source directory: /usr/src/googletest/googletest
+# Build directory: /app/googletest/googletest
+#
+# This file includes the relevant testing commands required for
+# testing this directory and lists subdirectories to be tested as well.

--- a/googletest/googletest/generated/GTestConfig.cmake
+++ b/googletest/googletest/generated/GTestConfig.cmake
@@ -1,0 +1,34 @@
+
+####### Expanded from @PACKAGE_INIT@ by configure_package_config_file() #######
+####### Any changes to this file will be overwritten by the next CMake run ####
+####### The input file was Config.cmake.in                            ########
+
+get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
+
+macro(set_and_check _var _file)
+  set(${_var} "${_file}")
+  if(NOT EXISTS "${_file}")
+    message(FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist !")
+  endif()
+endmacro()
+
+macro(check_required_components _NAME)
+  foreach(comp ${${_NAME}_FIND_COMPONENTS})
+    if(NOT ${_NAME}_${comp}_FOUND)
+      if(${_NAME}_FIND_REQUIRED_${comp})
+        set(${_NAME}_FOUND FALSE)
+      endif()
+    endif()
+  endforeach()
+endmacro()
+
+####################################################################################
+include(CMakeFindDependencyMacro)
+if (ON)
+  set(THREADS_PREFER_PTHREAD_FLAG )
+  find_dependency(Threads)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/GTestTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/GMockTargets.cmake" OPTIONAL)
+check_required_components("")

--- a/googletest/googletest/generated/GTestConfigVersion.cmake
+++ b/googletest/googletest/generated/GTestConfigVersion.cmake
@@ -1,0 +1,43 @@
+# This is a basic version file for the Config-mode of find_package().
+# It is used by write_basic_package_version_file() as input file for configure_file()
+# to create a version-file which can be installed along a config.cmake file.
+#
+# The created file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version.
+# The variable CVF_VERSION must be set before calling configure_file().
+
+set(PACKAGE_VERSION "1.14.0")
+
+if (PACKAGE_FIND_VERSION_RANGE)
+  # Package version must be in the requested version range
+  if ((PACKAGE_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      OR ((PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+        OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND PACKAGE_VERSION VERSION_GREATER_EQUAL PACKAGE_FIND_VERSION_MAX)))
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  endif()
+else()
+  if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()
+
+
+# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "8" STREQUAL "")
+  return()
+endif()
+
+# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "8")
+  math(EXPR installedBits "8 * 8")
+  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif()

--- a/googletest/googletest/generated/gmock.pc
+++ b/googletest/googletest/generated/gmock.pc
@@ -1,0 +1,10 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gmock
+Description: GoogleMock (without main() function)
+Version: 1.14.0
+URL: https://github.com/google/googletest
+Requires: gtest = 1.14.0
+Libs: -L${libdir} -lgmock
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1

--- a/googletest/googletest/generated/gmock_main.pc
+++ b/googletest/googletest/generated/gmock_main.pc
@@ -1,0 +1,10 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gmock_main
+Description: GoogleMock (with main() function)
+Version: 1.14.0
+URL: https://github.com/google/googletest
+Requires: gmock = 1.14.0
+Libs: -L${libdir} -lgmock_main
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1

--- a/googletest/googletest/generated/gtest.pc
+++ b/googletest/googletest/generated/gtest.pc
@@ -1,0 +1,9 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gtest
+Description: GoogleTest (without main() function)
+Version: 1.14.0
+URL: https://github.com/google/googletest
+Libs: -L${libdir} -lgtest
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1

--- a/googletest/googletest/generated/gtest_main.pc
+++ b/googletest/googletest/generated/gtest_main.pc
@@ -1,0 +1,10 @@
+libdir=/usr/local/lib
+includedir=/usr/local/include
+
+Name: gtest_main
+Description: GoogleTest (with main() function)
+Version: 1.14.0
+URL: https://github.com/google/googletest
+Requires: gtest = 1.14.0
+Libs: -L${libdir} -lgtest_main
+Cflags: -I${includedir} -DGTEST_HAS_PTHREAD=1

--- a/include/redisjson++/lua_script_manager.h
+++ b/include/redisjson++/lua_script_manager.h
@@ -90,7 +90,16 @@ private:
     // These could be static const strings or loaded from files/resources.
     static const std::string JSON_GET_SET_LUA; // Old, to be reviewed/removed if not used
     static const std::string JSON_COMPARE_SET_LUA; // Old, to be reviewed/removed if not used
-    // New scripts for RedisJSON path operations
+
+    // Built-in Lua script strings
+    static const std::string JSON_PATH_GET_LUA;
+    static const std::string JSON_PATH_SET_LUA;
+    static const std::string JSON_PATH_DEL_LUA;
+    static const std::string JSON_PATH_TYPE_LUA;
+    static const std::string JSON_ARRAY_APPEND_LUA;
+    static const std::string JSON_ARRAY_PREPEND_LUA;
+    static const std::string JSON_ARRAY_POP_LUA;
+    static const std::string JSON_ARRAY_LENGTH_LUA;
     static const std::string ATOMIC_JSON_GET_SET_PATH_LUA;
     static const std::string ATOMIC_JSON_COMPARE_SET_PATH_LUA;
     // ... other built-in scripts

--- a/src/lua_script_manager.cpp
+++ b/src/lua_script_manager.cpp
@@ -1,5 +1,6 @@
 #include "redisjson++/lua_script_manager.h"
 #include "redisjson++/redis_connection_manager.h" // For RedisConnection
+#include "redisjson++/hiredis_RAII.h" // For RedisReplyPtr
 #include "redisjson++/exceptions.h" // For JsonParsingException, LuaScriptException
 #include <vector>
 #include <string>

--- a/unit_tests[1]_include.cmake
+++ b/unit_tests[1]_include.cmake
@@ -1,0 +1,5 @@
+if(EXISTS "/app/unit_tests[1]_tests.cmake")
+  include("/app/unit_tests[1]_tests.cmake")
+else()
+  add_test(unit_tests_NOT_BUILT unit_tests_NOT_BUILT)
+endif()


### PR DESCRIPTION
- Added static declarations for Lua script string constants in lua_script_manager.h.
- Included hiredis_RAII.h in lua_script_manager.cpp to define RedisReplyPtr.
- Installed libhiredis-dev and libgtest-dev dependencies.
- Modified CMakeLists.txt to build GTest using add_subdirectory for better robustness.
- Added .gitignore to exclude build artifacts and common temporary files.