### PR TITLE
Feat: Separate sample into SWSS and non-SWSS executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,20 +75,23 @@ include(GoogleTest)
 gtest_discover_tests(unit_tests)
 
 # --- Examples ---
+# Non-SWSS Sample Program (formerly redisjson_sample_program)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples/sample.cpp")
-    add_executable(redisjson_sample_program examples/sample.cpp)
-    target_link_libraries(redisjson_sample_program PRIVATE redisjson++)
-
-    # With redisjson++ linking hiredis PUBLICly (now via system libs),
-
-    
-
-    # redisjson_sample_program will also link to hiredis and get its includes correctly.
-    message(STATUS "Added example program target: redisjson_sample_program")
+    add_executable(redisjson_sample_non_swss examples/sample.cpp)
+    target_link_libraries(redisjson_sample_non_swss PRIVATE redisjson++)
+    message(STATUS "Added example program target: redisjson_sample_non_swss (Non-SWSS mode)")
 else()
-    message(STATUS "examples/sample.cpp not found, redisjson_sample_program target not created.")
+    message(STATUS "examples/sample.cpp not found, redisjson_sample_non_swss target not created.")
 endif()
 
+# SWSS Sample Program
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples/sample_swss.cpp")
+    add_executable(redisjson_sample_swss examples/sample_swss.cpp)
+    target_link_libraries(redisjson_sample_swss PRIVATE redisjson++)
+    message(STATUS "Added example program target: redisjson_sample_swss (SWSS mode)")
+else()
+    message(STATUS "examples/sample_swss.cpp not found, redisjson_sample_swss target not created.")
+endif()
 
 # Installation (optional)
 # install(TARGETS redisjson++ DESTINATION lib)


### PR DESCRIPTION
- Created examples/sample_swss.cpp for SWSS-only mode.
- Modified examples/sample.cpp for non-SWSS-only mode (legacy).
- Updated CMakeLists.txt to build two separate executables:
  - redisjson_sample_swss
  - redisjson_sample_non_swss
- Installed libhiredis-dev dependency for building.