### PR TITLE
feat: Implement JSON.ARRTRIM command

### DIFF
--- a/include/redisjson++/json_modifier.h
+++ b/include/redisjson++/json_modifier.h
@@ -75,6 +75,8 @@ public:
                    int index = -1); // -1 for last element
     void array_insert(json& document, const std::vector<PathParser::PathElement>& path_elements,
                       int index, const json& value_to_insert);
+    long long array_trim(json& document, const std::vector<PathParser::PathElement>& path_elements,
+                         long long start, long long stop);
     // size_t array_length(const json& document, const std::vector<PathParser::PathElement>& path_elements) const; // In requirements but might be better in get_size or similar
 
     // Utility Operations

--- a/include/redisjson++/lua_script_manager.h
+++ b/include/redisjson++/lua_script_manager.h
@@ -117,6 +117,7 @@ private:
     static const std::string JSON_ARRAY_INSERT_LUA;
     static const std::string JSON_CLEAR_LUA;
     static const std::string JSON_ARRINDEX_LUA;
+    static const std::string JSON_ARRAY_TRIM_LUA;
     // ... other built-in scripts
 };
 

--- a/include/redisjson++/redis_json_client.h
+++ b/include/redisjson++/redis_json_client.h
@@ -185,6 +185,7 @@ public:
                   int index = -1);
     size_t array_length(const std::string& key, const std::string& path) const;
     long long arrinsert(const std::string& key, const std::string& path, int index, const std::vector<json>& values);
+    long long json_array_trim(const std::string& key, const std::string& path, long long start_index, long long stop_index);
 
 
     // Merge Operations (client-side or specific command needed)


### PR DESCRIPTION
Implements the JSON.ARRTRIM command, allowing trimming of arrays to a specified inclusive range.

Includes:
- JSON_ARRAY_TRIM_LUA script for core logic.
- RedisJSONClient::json_array_trim C++ client function.
- JSONModifier::array_trim for SWSS mode.
- Unit tests for the Lua script in test_lua_script_manager.cpp.
- Examples in sample.cpp.

Note: Test execution in the provided environment timed out repeatedly, likely due to issues with Redis connection attempts in the test fixture setup when Redis is unavailable. The implemented code and tests are submitted based on the requirements, but full test verification was not possible.